### PR TITLE
Integrate with Renovate Bot

### DIFF
--- a/.github/workflows/auto-lock.yaml
+++ b/.github/workflows/auto-lock.yaml
@@ -1,0 +1,38 @@
+name: Auto-Lock Images
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "**/build.yaml"
+  workflow_dispatch:
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+
+      - name: Run Locker Script
+        run: python3 scripts/lock_builds.py
+
+      - name: Commit and Push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: pin docker digests in build.yaml"
+          file_pattern: "**/build.yaml docker-lock.json"

--- a/.github/workflows/verify-locks.yaml
+++ b/.github/workflows/verify-locks.yaml
@@ -1,0 +1,35 @@
+name: Verify Image Pinning
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for unpinned images
+        run: |
+          errors=0
+          # Search for images in build.yaml that don't have @sha256
+          # We look for lines like:   arch: "image:tag" (missing @sha256)
+          while IFS= read -r file; do
+            echo "Checking $file..."
+            # Regex matches architecture keys with values in quotes that DO NOT contain @sha256
+            if grep -E '^\s+(aarch64|amd64|armhf|armv7|i386):\s+"[^"]+"' "$file" | grep -v "@sha256:"; then
+              echo "Error: Unpinned image(s) found in $file"
+              grep -E '^\s+(aarch64|amd64|armhf|armv7|i386):\s+"[^"]+"' "$file" | grep -v "@sha256:"
+              errors=$((errors + 1))
+            fi
+          done < <(find . -name "build.yaml")
+
+          if [ $errors -gt 0 ]; then
+            echo "Found $errors file(s) with unpinned images. Please run scripts/lock_builds.py."
+            exit 1
+          fi
+          echo "All images are properly pinned."

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,6 +33,17 @@
       }
     },
     {
+      "label": "Lock Build Digests",
+      "type": "shell",
+      "command": "python3 scripts/lock_builds.py",
+      "group": "none",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "Rebuild and Start Addon",
       "type": "shell",
       "command": "ha addons rebuild \"local_${input:addonName}\"; ha addons start \"local_${input:addonName}\"; docker logs --follow \"addon_local_${input:addonName}\"",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "pinDigests": true,
+  "packageRules": [
+    {
+      "matchPackageNames": ["ghcr.io/hassio-addons/**", "lscr.io/linuxserver/**"],
+      "groupName": "base images",
+      "groupSlug": "base-images",
+      "schedule": ["at any time"]
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["(^|/)build\\.yaml$"],
+      "matchStrings": [
+        "\\s+(?<arch>aarch64|amd64|armhf|armv7|i386):\\s+\"(?<depName>[^\"]+):(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ]
+}

--- a/scripts/lock_builds.py
+++ b/scripts/lock_builds.py
@@ -1,0 +1,99 @@
+import os
+import re
+import subprocess
+import json
+
+LOCK_FILE = "docker-lock.json"
+
+ARCH_MAP = {
+    "aarch64": "arm64",
+    "amd64": "amd64",
+    "armhf": "arm",
+    "armv7": "arm",
+    "i386": "386"
+}
+
+def get_digest(image, arch=None):
+    """Fetch the SHA256 digest for an image using skopeo."""
+    print(f"Fetching digest for {image} ({arch if arch else 'default arch'})...")
+    try:
+        cmd = ["skopeo", "inspect"]
+        if arch and arch in ARCH_MAP:
+            cmd.extend(["--override-arch", ARCH_MAP[arch]])
+        cmd.append(f"docker://{image}")
+        
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        data = json.loads(result.stdout)
+        return data.get("Digest")
+    except subprocess.CalledProcessError as e:
+        print(f"Error fetching digest for {image}: {e.stderr}")
+        return None
+
+def lock_build_yaml(file_path, lock_data):
+    """Update build.yaml with pinned digests."""
+    with open(file_path, 'r') as f:
+        content = f.read()
+
+    # Regex to find architecture-specific images in build.yaml
+    # Matches:   amd64: "image:tag"
+    pattern = re.compile(r'(\s+)(\w+):\s+"([^"@]+)(?::([^"@]+))?(@sha256:[a-f0-9]+)?"')
+    
+    new_content = content
+    changes_made = False
+
+    for match in pattern.finditer(content):
+        indent, arch, image_name, tag, existing_digest = match.groups()
+        
+        # Construct the full image reference for skopeo
+        full_ref = f"{image_name}:{tag}" if tag else image_name
+        
+        # If already pinned, we might want to verify or update it
+        if existing_digest:
+            print(f"  {arch} is already pinned: {existing_digest}")
+            # We add it to lock_data anyway for sync
+            lock_data[full_ref] = existing_digest
+            continue
+
+        # Fetch new digest
+        digest = get_digest(full_ref, arch)
+        if digest:
+            print(f"  Found digest for {arch}: {digest}")
+            # Replace image:tag with image:tag@sha256:digest
+            old_str = f'"{full_ref}"'
+            new_str = f'"{full_ref}@{digest}"'
+            new_content = new_content.replace(old_str, new_str)
+            lock_data[full_ref] = digest
+            changes_made = True
+
+    if changes_made:
+        with open(file_path, 'w') as f:
+            f.write(new_content)
+        print(f"Updated {file_path}")
+    else:
+        print(f"No changes needed for {file_path}")
+
+def main():
+    lock_data = {}
+    if os.path.exists(LOCK_FILE):
+        with open(LOCK_FILE, 'r') as f:
+            lock_data = json.load(f)
+
+    # Find all build.yaml files
+    for root, dirs, files in os.walk('.'):
+        if 'build.yaml' in files:
+            file_path = os.path.join(root, 'build.yaml')
+            print(f"Processing {file_path}...")
+            lock_build_yaml(file_path, lock_data)
+
+    # Save the central lock file
+    with open(LOCK_FILE, 'w') as f:
+        json.dump(lock_data, f, indent=2)
+    print(f"Updated {LOCK_FILE}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
  This PR implements a mandatory, cryptographically secure verification layer for all Docker base images used in this repository. It ensures that the exact image bits verified during development are what the end-user installs, protecting against "tag drifting" and registry tampering.

## Key Changes
   - renovate.json: Configures Renovate Bot to provide "push-style" notifications for new base image versions, including automatic SHA256 digest pinning.
   - scripts/lock_builds.py: A new Python utility that uses skopeo to fetch immutable digests for all architectures and update build.yaml files in-place.
   - .github/workflows/auto-lock.yaml: An automated GitHub Action that detects unpinned images on push and automatically commits the correct SHA256 digests.
   - .github/workflows/verify-locks.yaml: CI enforcement that blocks any PR containing unpinned images.
   - docker-lock.json: A central manifest tracking all verified image digests.
   - .vscode/tasks.json: Added a "Lock Build Digests" task for local development convenience.

### The New Workflow
   1. Automatic Updates: Renovate Bot will monitor registries and open PRs for new versions (e.g., Python 18.0.0). These PRs will already be pinned to the correct digest.
   2. Manual Updates: If you manually update a version tag in build.yaml, the Auto-Lock GitHub Action will immediately fetch the digest and commit it for you.
   3. Local Locking: You can run the "Lock Build Digests" task in VS Code to pin images before pushing.

## Security Impact
  By using Native Docker Digest Pinning (image:tag@sha256:...), the Home Assistant Supervisor (and the underlying Docker engine) will now perform a cryptographic check during every installation. If the base image content changes upstream without a corresponding update in this repository, the installation will be blocked, ensuring end-user integrity.
